### PR TITLE
feat: `getState` to allow pass state from fresh to invoke at tool call

### DIFF
--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -55,6 +55,7 @@ export interface Options<TManifest extends AppManifest> {
     listTools?: ListToolsMiddleware[];
     callTool?: CallToolMiddleware[];
   };
+  getState?: () => unknown;
 }
 
 interface RootSchema extends JSONSchema7 {
@@ -244,6 +245,7 @@ function registerTools<TManifest extends AppManifest>(
           raw: new Request("http://localhost:8000"),
           param: () => ({}),
         },
+        base: options?.getState?.(),
       });
       // Use the original name from the map when invoking
       if (!toolNames) {


### PR DESCRIPTION
Example: 
```ts
// fresh middleware
const asyncLocalStorage = new AsyncLocalStorage()

// middleware
function setAuthUser() {
  // some code
  ctx.state.user = user;

  return await asyncLocalStorage.run(ctx.state, async () => {
     return await ctx.next();
  })
}
```

```ts
// fresh.config.ts
//...
{ //...
  useServer: (deco, hono) => {
     const options = {
        getState: () => asyncLocalStorage.getStore()
     };
     hono.use('/*', mcpServer(deco, options));
  }
}
// ...
```