### PR TITLE
Deref fix: Arrays and allOf

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@deco/mcp",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "exports": "./mod.ts",
   "tasks": {
     "check": "deno fmt && deno lint && deno check mod.ts"

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -134,7 +134,7 @@ export const getTools = <TManifest extends AppManifest>(
       // Dereference the input schema
       const inputSchema = rawInputSchema
         ? dereferenceSchema(
-          rawInputSchema as JSONSchema7,
+          {...rawInputSchema, log: funcDefinition.title?.includes('Create Highlights') } as JSONSchema7,
           schemas.definitions,
         )
         : undefined;

--- a/mcp/server.ts
+++ b/mcp/server.ts
@@ -134,7 +134,7 @@ export const getTools = <TManifest extends AppManifest>(
       // Dereference the input schema
       const inputSchema = rawInputSchema
         ? dereferenceSchema(
-          {...rawInputSchema, log: funcDefinition.title?.includes('Create Highlights') } as JSONSchema7,
+          rawInputSchema as JSONSchema7,
           schemas.definitions,
         )
         : undefined;

--- a/mcp/utils.ts
+++ b/mcp/utils.ts
@@ -6,6 +6,10 @@ export function dereferenceSchema(
   definitions: { [key: string]: JSONSchema7 },
   visited = new Set<string>(),
 ): JSONSchema7 | undefined {
+  if (schema?.log) {
+    console.log({ schema });
+    console.log(definitions['aHR0cHM6Ly9jZG4uanNkZWxpdnIubmV0L2doL2RlY28tY3gvYXBwc0AwLjc0LjAvcmVhZHdpc2UvY2xpZW50LnRz@HighlightItem']);
+  }
   if (!schema) return undefined;
 
   // Handle array types by converting to anyOf
@@ -43,6 +47,15 @@ export function dereferenceSchema(
   }
 
   const result: JSONSchema7 = { ...schema };
+
+  // Handle arrays with items
+  if (result.type === "array" && result.items) {
+    result.items = dereferenceSchema(
+      result.items as JSONSchema7,
+      definitions,
+      visited,
+    ) as JSONSchema7;
+  }
 
   // Handle allOf
   if (result.allOf) {


### PR DESCRIPTION
## Array Items
**Before**
![image](https://github.com/user-attachments/assets/e107919d-a6e7-46c1-8310-4644841c1023)


**After**
![Cursor 2025-04-14 14 30 59](https://github.com/user-attachments/assets/36c85149-4dfd-4926-8368-763b199b7569)


## allOf - apparently some LLMs are no fans of them.

**Before**
![image](https://github.com/user-attachments/assets/ee3c3432-9491-430f-904f-966db5197764)

**After**
![iTerm2 2025-04-14 14 36 53](https://github.com/user-attachments/assets/002e5976-6aac-4607-9562-f18e5618800d)
